### PR TITLE
Add tags as hash

### DIFF
--- a/lib/nike_v2/activity.rb
+++ b/lib/nike_v2/activity.rb
@@ -60,6 +60,10 @@ module NikeV2
       end
     end
 
+    def tags_as_hash
+      Hash[tags.map {|k| [k['tagType'].downcase.to_sym, k['tagValue']] }]
+    end
+
     private 
     def api_url
       API_URL + "/#{self.activity_id}"

--- a/spec/fixtures/nike_api_cassettes/activity.yml
+++ b/spec/fixtures/nike_api_cassettes/activity.yml
@@ -34,10 +34,10 @@ http_interactions:
         257, "fuel": 662, "distance": 3.1317999362945557, "steps": 10, "duration":
         "0:14:31.000", "activityType": "RUN", "startTime": "2011-08-11T07:00:00Z",
         "activityTimeZone": "America/Phoenix", "status": "COMPLETE", "deviceType": "SPORTWATCH",
-        "tags": [ { "tagType": "NOTE", "value": "text string" }, { "tagType": "COURT",
-        "value": "DUNK" }, { "tagType": "TERRAIN", "value": "TRAIL" }, { "tagType":
-        "EMOTION", "value": "HAPPY" }, { "tagType": "SHOES", "value": "AirMax" },
-        { "tagType": "WEATHER", "value": "RAINY" } ], "metrics": [ { "intervalMetric":
+        "tags": [ { "tagType": "NOTE", "tagValue": "text string" }, { "tagType": "COURT",
+        "tagValue": "DUNK" }, { "tagType": "TERRAIN", "tagValue": "TRAIL" }, { "tagType":
+        "EMOTION", "tagValue": "HAPPY" }, { "tagType": "SHOES", "tagValue": "AirMax" },
+        { "tagType": "WEATHER", "tagValue": "RAINY" } ], "metrics": [ { "intervalMetric":
         10, "intervalUnit": "SEC", "metricType": "DISTANCE", "values": [ 0.0299, 0.0562,
         0.0794, 0.114, 3.0967, 3.1296 ] }, { "intervalMetric": 1, "intervalUnit":
         "MIN", "metricType": "FUEL", "values": [ "21", "8", "21", "3", "19", "19",

--- a/spec/nike_v2/activity_spec.rb
+++ b/spec/nike_v2/activity_spec.rb
@@ -21,4 +21,21 @@ describe NikeV2::Activity do
       activity.total_fuel_during(Time.parse('2011-08-11T00:00:00-07:00'), Time.parse('2011-08-11T01:00:00-07:00'), true).should == 883.0
     end
   end
+
+  describe 'tags_as_hash' do
+    it "knows how to translate Nike's tag format to a more conventional hash" do
+      VCR.use_cassette 'activity' do
+        activity.load_data
+        conventional_hash = {
+          note: "text string",
+          court: "DUNK",
+          terrain: "TRAIL",
+          emotion: "HAPPY",
+          shoes: "AirMax",
+          weather: "RAINY"
+        }
+        activity.tags_as_hash.should eq(conventional_hash)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Two commits, two changes:
1) Nike apparently changed their tags format at some point (and didn't update their documentation), so I updated the activity cassette to match what the API actually returns.
2) Added Activity#tags_as_hash that transforms the Nike tags format into an idiomatic Ruby hash.
