### PR TITLE
add a version number to calls to nike API

### DIFF
--- a/lib/nike_v2/resource.rb
+++ b/lib/nike_v2/resource.rb
@@ -5,7 +5,7 @@ module NikeV2
     include HTTParty
     include HTTParty::Sober
 
-    base_uri 'https://api.nike.com'
+    base_uri 'https://api.nike.com/v1'
 
     RESP_MSG_INVALID_TOKEN = 'invalid_token'
 

--- a/spec/fixtures/nike_api_cassettes/activities.yml
+++ b/spec/fixtures/nike_api_cassettes/activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nike.com/me/sport/activities?access_token=foobar
+    uri: https://api.nike.com/v1/me/sport/activities?access_token=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -30,7 +30,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"data":[{"activityId":"91b501dc-4a38-44aa-b537-6095418713d8","calories":2475,"fuel":7500,"distance":19.665315,"steps":24975,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-26T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[],"metrics":[]},{"activityId":"8554c3bb-f985-4700-a52d-6235475a10f0","calories":1848,"fuel":5555,"distance":14.6834352,"steps":18648,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-25T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"b7511567-9414-429a-9b7b-40ebc15af985","calories":396,"fuel":1200,"distance":3.1464504,"steps":3996,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-24T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"b87bb409-a618-47ee-a75e-1bb5f8daf9a6","calories":300,"fuel":900,"distance":2.3621999999999996,"steps":3000,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-23T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"6c6eb89c-fa42-49a6-8b04-2596297a7c3a","calories":200,"fuel":600,"distance":1.5748,"steps":2000,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-22T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]}],"paging":{"next":"/me/sport/activities?access_token=foobar&amp;offset=6&amp;count=5","previous":null}}'
+      string: '{"data":[{"activityId":"91b501dc-4a38-44aa-b537-6095418713d8","calories":2475,"fuel":7500,"distance":19.665315,"steps":24975,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-26T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[],"metrics":[]},{"activityId":"8554c3bb-f985-4700-a52d-6235475a10f0","calories":1848,"fuel":5555,"distance":14.6834352,"steps":18648,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-25T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"b7511567-9414-429a-9b7b-40ebc15af985","calories":396,"fuel":1200,"distance":3.1464504,"steps":3996,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-24T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"b87bb409-a618-47ee-a75e-1bb5f8daf9a6","calories":300,"fuel":900,"distance":2.3621999999999996,"steps":3000,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-23T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]},{"activityId":"6c6eb89c-fa42-49a6-8b04-2596297a7c3a","calories":200,"fuel":600,"distance":1.5748,"steps":2000,"duration":"0:01:00.0000","activityType":"ALL_DAY","startTime":"2012-02-22T08:00:00Z","activityTimeZone":"America/Los_Angeles","status":"COMPLETE","deviceType":"FUELBAND","tags":[],"streams":[]}],"paging":{"next":"/me/sport/activities?access_token=foobar&amp;offset=6&amp;count=5","previous":null}}'
     http_version: 
   recorded_at: Sun, 20 Jan 2013 04:21:05 GMT
 - request:
@@ -63,7 +63,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc9f",
+      string: '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc9f",
         "calories": 581, "fuel": 1653, "distance": 2.0936965942382812, "steps": 2659,
         "duration": "7:02:00.000", "activityType": "ALL_DAY", "startTime": "2013-02-26T07:00:00Z",
         "activityTimeZone": "America/Phoenix", "status": "IN_PROGRESS", "deviceType":
@@ -101,7 +101,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc9f",
+      string: '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc9f",
         "calories": 581, "fuel": 1653, "distance": 2.0936965942382812, "steps": 2659,
         "duration": "7:02:00.000", "activityType": "ALL_DAY", "startTime": "2013-01-01T07:00:00Z",
         "activityTimeZone": "America/Phoenix", "status": "IN_PROGRESS", "deviceType":
@@ -139,7 +139,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{ "activityId": "91b501dc-4a38-44aa-b537-6095418713d8", "calories":
+      string: '{ "activityId": "91b501dc-4a38-44aa-b537-6095418713d8", "calories":
         257, "fuel": 662, "distance": 3.1317999362945557, "steps": 10, "duration":
         "0:14:31.000", "activityType": "RUN", "startTime": "2011-08-11T00:00:00Z",
         "activityTimeZone": "GMT-08:00", "status": "COMPLETE", "deviceType": "SPORTWATCH",
@@ -289,7 +289,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc91",
+      string: '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc91",
         "calories": 581, "fuel": 1653, "distance": 2.0936965942382812, "steps": 2659,
         "duration": "7:02:00.000", "activityType": "ALL_DAY", "startTime": "2013-02-26T07:00:00Z",
         "activityTimeZone": "America/Phoenix", "status": "IN_PROGRESS", "deviceType":
@@ -327,7 +327,7 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc92",
+      string: '{ "data": [ { "activityId": "c3337642-72db-41f7-b4a2-4da4600dfc92",
         "calories": 581, "fuel": 1653, "distance": 2.0936965942382812, "steps": 2659,
         "duration": "7:02:00.000", "activityType": "ALL_DAY", "startTime": "2013-02-26T07:00:00Z",
         "activityTimeZone": "America/Phoenix", "status": "IN_PROGRESS", "deviceType":
@@ -364,7 +364,61 @@ http_interactions:
       - keep-alive
     body:
       encoding: US-ASCII
-      string: ! '{"data":[{"activityId":"1b4f5b2c-26c4-45cc-952a-d62c61cf506a","activityType":"ALL_DAY","startTime":"2013-03-30T07:00:00Z","activityTimeZone":"America/Phoenix","status":"NONE","deviceType":"FUELBAND","metricSummary":{"calories":1462,"fuel":4158,"distance":6.641719,"steps":8435,"duration":"8:48:00.000"},"tags":[],"metrics":[]}],"paging":{"next":"/me/sport/activities?count=1&startDate=2013-03-29&endDate=2013-03-29&access_token=foobar&offset=2"}}'
+      string: '{"data":[{"activityId":"1b4f5b2c-26c4-45cc-952a-d62c61cf506a","activityType":"ALL_DAY","startTime":"2013-03-30T07:00:00Z","activityTimeZone":"America/Phoenix","status":"NONE","deviceType":"FUELBAND","metricSummary":{"calories":1462,"fuel":4158,"distance":6.641719,"steps":8435,"duration":"8:48:00.000"},"tags":[],"metrics":[]}],"paging":{"next":"/me/sport/activities?count=1&startDate=2013-03-29&endDate=2013-03-29&access_token=foobar&offset=2"}}'
     http_version: 
   recorded_at: Sun, 31 Mar 2013 00:42:43 GMT
+- request:
+    method: get
+    uri: https://api.nike.com/v1/me/sport/activities?access_token=foobar&count=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Appid:
+      - nike
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "<error>invalid_token</error>\n            "
+    http_version: 
+  recorded_at: Sun, 07 Sep 2014 00:56:52 GMT
+- request:
+    method: get
+    uri: https://api.nike.com/v1/me/sport/activities?access_token=foobar&count=1&endDate=2013-03-29&startDate=2013-03-29
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      Appid:
+      - nike
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Content-Type:
+      - application/xml
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: "<error>invalid_token</error>\n            "
+    http_version: 
+  recorded_at: Sun, 07 Sep 2014 00:56:58 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/nike_api_cassettes/activity.yml
+++ b/spec/fixtures/nike_api_cassettes/activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nike.com/me/sport/activities/91b501dc-4a38-44aa-b537-6095418713d8?access_token=foobar
+    uri: https://api.nike.com/v1/me/sport/activities/91b501dc-4a38-44aa-b537-6095418713d8?access_token=foobar
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/nike_api_cassettes/gps_data.yml
+++ b/spec/fixtures/nike_api_cassettes/gps_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nike.com/me/sport/activities/91b501dc-4a38-44aa-b537-6095418713d8/gps?access_token=foobar
+    uri: https://api.nike.com/v1/me/sport/activities/91b501dc-4a38-44aa-b537-6095418713d8/gps?access_token=foobar
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/nike_api_cassettes/summary.yml
+++ b/spec/fixtures/nike_api_cassettes/summary.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.nike.com/me/sport?access_token=foobar
+    uri: https://api.nike.com/v1/me/sport?access_token=foobar
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/nike_v2/resource_spec.rb
+++ b/spec/nike_v2/resource_spec.rb
@@ -6,8 +6,8 @@ describe NikeV2::Resource do
   end
 
   describe '#base_uri' do
-    it 'should be set to https://api.nike.com' do
-      NikeV2::Resource.base_uri.should == 'https://api.nike.com'
+    it 'should be set to https://api.nike.com/v1' do
+      NikeV2::Resource.base_uri.should == 'https://api.nike.com/v1'
     end
   end
 end


### PR DESCRIPTION
It seems that calls to nike API needs a version number before between the domain name and the details of the path. For example:
https://api.nike.com/v1/me/sport/activities

On a call like "https://api.nike.com/me/sport/activities" I get a 401 "Unauthorized" with a body of:
<error>invalid_token</error>

adding /v1 of to the path seems to do the trick.
